### PR TITLE
Add support for custom 2FA HTML templates and embed default template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /caddy
 /Caddyfile
 /2fa-secrets-example.json
+/2fa_form-custom.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /caddy
 /Caddyfile
 /2fa-secrets-example.json
-/2fa_form-custom.html
+/2fa-form-custom.html

--- a/2fa-form-html.go
+++ b/2fa-form-html.go
@@ -26,7 +26,7 @@ import (
 
 // default2FAFormHTML contains the default HTML content for the 2FA form.
 // By default, its value is an embedded document. To configure a custom
-// HTML form, set Caddyfile directive `template_file` to the path of
+// HTML form, set Caddyfile subdirective `form_template` to the path of
 // an external HTML file.
 //
 //go:embed default-2fa-form.html
@@ -53,18 +53,18 @@ func generateNonce() (string, error) {
 func (m *BasicAuthTOTP) provisionTemplate() error {
 	var err error
 	// Load the external custom HTML template if set
-	if m.TemplateFile != "" {
-		m.Template, err = template.ParseFiles(m.TemplateFile)
+	if m.FormTemplateFile != "" {
+		m.Template, err = template.ParseFiles(m.FormTemplateFile)
 		if err != nil {
 			m.logger.Warn("failed to load custom 2FA form template, using default",
-				zap.String("template_path", m.TemplateFile),
+				zap.String("template_path", m.FormTemplateFile),
 				zap.Error(err))
 		}
 	}
 
 	// Use the default HTML template if no custom template is set
 	// or if there was an error loading the custom template
-	if m.TemplateFile == "" || err != nil {
+	if m.FormTemplateFile == "" || err != nil {
 		// Parse the embedded HTML content
 		m.Template, err = template.New("2fa_form").Parse(default2FAFormHTML)
 		if err != nil {

--- a/2fa-form-html.go
+++ b/2fa-form-html.go
@@ -32,8 +32,8 @@ import (
 //go:embed default-2fa-form.html
 var default2FAFormHTML string
 
-// FormData holds the data to be passed to the 2FA form template
-type FormData struct {
+// formData holds the data to be passed to the 2FA form template
+type formData struct {
 	Nonce        string
 	ErrorMessage string
 	Username     string
@@ -79,7 +79,7 @@ func (m *BasicAuthTOTP) provisionTemplate() error {
 // show2FAForm displays a styled 2FA form with an error message if provided.
 // It generates a nonce for the Content-Security-Policy and uses either a custom
 // or default HTML template to render the form.
-func (m *BasicAuthTOTP) show2FAForm(w http.ResponseWriter, formData FormData) {
+func (m *BasicAuthTOTP) show2FAForm(w http.ResponseWriter, formData formData) {
 	// Generate a nonce for this request
 	nonce, err := generateNonce()
 	if err != nil {

--- a/2fa-form-html.go
+++ b/2fa-form-html.go
@@ -16,11 +16,21 @@ package basicauthtotp
 
 import (
 	"crypto/rand"
+	_ "embed"
 	"encoding/base64"
+	"html/template"
 	"net/http"
 
 	"go.uber.org/zap"
 )
+
+// Default2FAFormHTML contains the default HTML content for the 2FA form.
+// By default, its value is an embedded document. To configure a custom
+// HTML form, set use Caddyfile directive `template_file` to the path of
+// an external HTML file.
+//
+//go:embed default-2fa-form.html
+var Default2FAFormHTML string
 
 // generateNonce generates a random base64 nonce
 func generateNonce() (string, error) {
@@ -32,15 +42,48 @@ func generateNonce() (string, error) {
 	return base64.StdEncoding.EncodeToString(nonceBytes), nil
 }
 
-// show2FAForm displays a styled 2FA form with a custom error message if provided.
+// show2FAForm displays a styled 2FA form with an error message if provided.
+// It generates a nonce for the Content-Security-Policy and uses either a custom
+// or default HTML template to render the form.
 func (m *BasicAuthTOTP) show2FAForm(w http.ResponseWriter, errorMessage string) {
 	// Generate a nonce for this request
 	nonce, err := generateNonce()
 	if err != nil {
-		m.logger.Error("failed to generate nonce for 2FA form: ",
+		m.logger.Error("failed to generate nonce for 2FA form",
 			zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
+	}
+
+	var tmpl *template.Template
+	if m.TemplateFile != "" {
+		// Load the external custom HTML template
+		tmpl, err = template.ParseFiles(m.TemplateFile)
+		if err != nil {
+			m.logger.Error("failed to load custom 2FA form template",
+				zap.String("template_path", m.TemplateFile),
+				zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		// Parse the embedded HTML content
+		tmpl, err = template.New("2fa_form").Parse(Default2FAFormHTML)
+		if err != nil {
+			m.logger.Error("failed to parse default 2FA form template",
+				zap.Error(err))
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Prepare the data to pass to the template
+	data := struct {
+		Nonce        string
+		ErrorMessage string
+	}{
+		Nonce:        nonce,
+		ErrorMessage: errorMessage,
 	}
 
 	// Set the Content-Type and Content-Security-Policy headers with nonce
@@ -48,97 +91,11 @@ func (m *BasicAuthTOTP) show2FAForm(w http.ResponseWriter, errorMessage string) 
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'self' 'nonce-"+nonce+"'; form-action 'self';")
 	w.WriteHeader(http.StatusOK)
 
-	// Set the error message HTML if an error message is provided
-	errorMessageHTML := ""
-	if errorMessage != "" {
-		errorMessageHTML = `<p class="error-message">` + errorMessage + `</p>`
+	// Execute the template and write the output to the response
+	if err := tmpl.Execute(w, data); err != nil {
+		m.logger.Error("failed to execute 2FA form template",
+			zap.Error(err))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
-
-	formHTML := `
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>2FA Authentication</title>
-            <style nonce="` + nonce + `">
-				body {
-					font-family: Arial, sans-serif;
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					height: 100vh;
-					margin: 0;
-					background-color: #f4f4f9;
-				}
-				.container {
-					text-align: center;
-					width: 100%;
-					max-width: 400px;
-					background-color: #ffffff;
-					padding: 20px;
-					border-radius: 8px;
-					box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-					box-sizing: border-box;
-					min-height: 280px;
-				}
-				h1 {
-					font-size: 1.6em;
-					color: #333;
-					margin-bottom: 0.8em;
-				}
-				p {
-					font-size: 1em;
-					color: #555;
-					margin-bottom: 1em;
-				}
-				label {
-					display: block;
-					font-size: 0.9em;
-					color: #333;
-					margin-bottom: 0.5em;
-				}
-				input[type="text"] {
-					width: 100%;
-					padding: 10px;
-					margin-bottom: 1em;
-					font-size: 1em;
-					border: 1px solid #ccc;
-					border-radius: 4px;
-					box-sizing: border-box;
-				}
-				button {
-					background-color: #4CAF50;
-					color: white;
-					padding: 10px 20px;
-					font-size: 1em;
-					border: none;
-					border-radius: 4px;
-					cursor: pointer;
-				}
-				button:hover {
-					background-color: #45a049;
-				}
-				.error-message {
-					color: #d9534f;
-					font-size: 0.9em;
-					margin-top: 1em;
-				}
-            </style>
-        </head>
-        <body>
-            <div class="container">
-                <h1>2FA Authentication Required</h1>
-                <p>Please enter your 2FA code to continue.</p>
-                <form method="POST" action="">
-                    <label for="totp_code">2FA Code:</label>
-                    <input type="text" id="totp_code" name="totp_code" size="30" maxlength="6" required autofocus>
-                    <button type="submit">Submit</button>
-                </form>
-                ` + errorMessageHTML + `
-            </div>
-        </body>
-        </html>`
-
-	w.Write([]byte(formHTML))
 }

--- a/2fa-form-html.go
+++ b/2fa-form-html.go
@@ -56,17 +56,19 @@ func (m *BasicAuthTOTP) show2FAForm(w http.ResponseWriter, errorMessage string) 
 	}
 
 	var tmpl *template.Template
+	// Load the external custom HTML template if set
 	if m.TemplateFile != "" {
-		// Load the external custom HTML template
 		tmpl, err = template.ParseFiles(m.TemplateFile)
 		if err != nil {
-			m.logger.Error("failed to load custom 2FA form template",
+			m.logger.Error("failed to load custom 2FA form template, using default",
 				zap.String("template_path", m.TemplateFile),
 				zap.Error(err))
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
 		}
-	} else {
+	}
+
+	// Use the default HTML template if no custom template is set
+	// or if there was an error loading the custom template
+	if m.TemplateFile == "" || err != nil {
 		// Parse the embedded HTML content
 		tmpl, err = template.New("2fa_form").Parse(Default2FAFormHTML)
 		if err != nil {

--- a/2fa-form-html.go
+++ b/2fa-form-html.go
@@ -54,7 +54,7 @@ func (m *BasicAuthTOTP) provisionTemplate() error {
 	var err error
 	// Load the external custom HTML template if set
 	if m.FormTemplateFile != "" {
-		m.Template, err = template.ParseFiles(m.FormTemplateFile)
+		m.formTemplate, err = template.ParseFiles(m.FormTemplateFile)
 		if err != nil {
 			m.logger.Warn("failed to load custom 2FA form template, using default",
 				zap.String("template_path", m.FormTemplateFile),
@@ -66,7 +66,7 @@ func (m *BasicAuthTOTP) provisionTemplate() error {
 	// or if there was an error loading the custom template
 	if m.FormTemplateFile == "" || err != nil {
 		// Parse the embedded HTML content
-		m.Template, err = template.New("2fa_form").Parse(default2FAFormHTML)
+		m.formTemplate, err = template.New("2fa_form").Parse(default2FAFormHTML)
 		if err != nil {
 			m.logger.Error("failed to parse default 2FA form template",
 				zap.Error(err))
@@ -98,7 +98,7 @@ func (m *BasicAuthTOTP) show2FAForm(w http.ResponseWriter, formData FormData) {
 	w.WriteHeader(http.StatusOK)
 
 	// Execute the template and write the output to the response
-	if err := m.Template.Execute(w, formData); err != nil {
+	if err := m.formTemplate.Execute(w, formData); err != nil {
 		m.logger.Error("failed to execute 2FA form template",
 			zap.Error(err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ By default, the `basic_auth_totp` directive is ordered after `basic_auth` in the
             secrets_file_path /path/to/2fa-secrets.json
             cookie_name batotp_sess
             cookie_path /top-secret
+            form_template /path/to/custom-2fa-form-template.html
             sign_key AWhvKpXr0CYdbW+Da+bBDTBX5nyqYCTKGNWpC0CeWhY=
         }
 
@@ -102,8 +103,18 @@ By default, the `basic_auth_totp` directive is ordered after `basic_auth` in the
 - **`cookie_path`**: Sets the path scope of the session cookie, defining where it will be sent on the server. Default is `/`.
   - *Usage Tip*: Ensure this aligns with the URL path protected by `basic_auth`, as the cookie will only be sent to matching paths.
 
+- **`form_template`**: Path to the HTML template file for the 2FA authentication page. If not specified, an embedded default template `default-2fa-form.html` will be used.
+
 - **`sign_key`**: The base64-encoded secret key used to sign the JWTs. This key will be decoded to bytes for JWT signing.
   - *Usage Tip*: To create a secure base64-encoded sign key, you can use the command `openssl rand -base64 32`.  This command generates a random 32-byte key and encodes it in base64 format.
+
+### Template Context
+
+The available information in the template context includes:
+
+- `Username`: The username of the user (HTML escaped).
+- `Errormessage`: Any error message to be displayed.
+- `Nonce`: A nonce used for inline styles.
 
 ### Session Management Explanation
 

--- a/basicauthtotp.go
+++ b/basicauthtotp.go
@@ -199,7 +199,7 @@ func (m *BasicAuthTOTP) ServeHTTP(w http.ResponseWriter, r *http.Request, next c
 
 	// Initialize FormData with the html escaped username
 	username = html.EscapeString(username)
-	formData := FormData{
+	formData := formData{
 		Username: username,
 	}
 

--- a/basicauthtotp.go
+++ b/basicauthtotp.go
@@ -84,7 +84,7 @@ type BasicAuthTOTP struct {
 	FormTemplateFile string `json:"form_template,omitempty"`
 
 	// template is the parsed HTML template used to render the 2FA form.
-	Template *template.Template
+	formTemplate *template.Template
 
 	// SignKey is the base64 encoded secret key used to sign the JWTs.
 	SignKey string `json:"sign_key,omitempty"`

--- a/basicauthtotp.go
+++ b/basicauthtotp.go
@@ -151,7 +151,7 @@ func (m *BasicAuthTOTP) Provision(ctx caddy.Context) error {
 		zap.String("SecretsFilePath", m.SecretsFilePath),
 		zap.String("CookieName", m.CookieName),
 		zap.String("CookiePath", m.CookiePath),
-		zap.String("TemplateFile", m.FormTemplateFile),
+		zap.String("FormTemplateFile", m.FormTemplateFile),
 		// SignKey is omitted from the log output for security reasons.
 	)
 	return nil

--- a/basicauthtotp.go
+++ b/basicauthtotp.go
@@ -134,7 +134,7 @@ func (m *BasicAuthTOTP) Provision(ctx caddy.Context) error {
 	}
 
 	var err error
-	m.signKeyBytes, err = base64.StdEncoding.DecodeString(string(m.SignKey))
+	m.signKeyBytes, err = base64.StdEncoding.DecodeString(m.SignKey)
 	if err != nil {
 		m.logger.Error("Failed to decode sign key", zap.Error(err))
 		return err

--- a/basicauthtotp.go
+++ b/basicauthtotp.go
@@ -80,8 +80,8 @@ type BasicAuthTOTP struct {
 	// This restricts where the cookie is sent on the server. Default is `/`.
 	CookiePath string `json:"cookie_path,omitempty"`
 
-	// Filename of the template to use instead of the embedded default template.
-	TemplateFile string `json:"template_file,omitempty"`
+	// Filename of the custom template to use instead of the embedded default template.
+	FormTemplateFile string `json:"form_template,omitempty"`
 
 	// template is the parsed HTML template used to render the 2FA form.
 	Template *template.Template
@@ -151,7 +151,7 @@ func (m *BasicAuthTOTP) Provision(ctx caddy.Context) error {
 		zap.String("SecretsFilePath", m.SecretsFilePath),
 		zap.String("CookieName", m.CookieName),
 		zap.String("CookiePath", m.CookiePath),
-		zap.String("TemplateFile", m.TemplateFile),
+		zap.String("TemplateFile", m.FormTemplateFile),
 		// SignKey is omitted from the log output for security reasons.
 	)
 	return nil

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -63,6 +63,8 @@ func (m *BasicAuthTOTP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				m.CookieName = arg
 			case "cookie_path":
 				m.CookiePath = arg
+			case "template_file":
+				m.TemplateFile = arg
 			case "sign_key":
 				m.SignKey = arg
 			case "logout_session_path":

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -63,8 +63,8 @@ func (m *BasicAuthTOTP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				m.CookieName = arg
 			case "cookie_path":
 				m.CookiePath = arg
-			case "template_file":
-				m.TemplateFile = arg
+			case "form_template":
+				m.FormTemplateFile = arg
 			case "sign_key":
 				m.SignKey = arg
 			case "logout_session_path":

--- a/default-2fa-form.html
+++ b/default-2fa-form.html
@@ -78,9 +78,9 @@
             <input type="text" id="totp_code" name="totp_code" size="30" maxlength="6" required autofocus>
             <button type="submit">Submit</button>
         </form>
-        {{ if .ErrorMessage }}
+        {{- if .ErrorMessage }}
         <p class="error-message">{{ .ErrorMessage }}</p>
-        {{ end }}
+        {{- end }}
     </div>
 </body>
 </html>

--- a/default-2fa-form.html
+++ b/default-2fa-form.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2FA Authentication</title>
+    <style nonce="{{ .Nonce }}">
+        body {
+            font-family: Arial, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f4f4f9;
+        }
+        .container {
+            text-align: center;
+            width: 100%;
+            max-width: 400px;
+            background-color: #ffffff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            box-sizing: border-box;
+            min-height: 280px;
+        }
+        h1 {
+            font-size: 1.6em;
+            color: #333;
+            margin-bottom: 0.8em;
+        }
+        p {
+            font-size: 1em;
+            color: #555;
+            margin-bottom: 1em;
+        }
+        label {
+            display: block;
+            font-size: 0.9em;
+            color: #333;
+            margin-bottom: 0.5em;
+        }
+        input[type="text"] {
+            width: 100%;
+            padding: 10px;
+            margin-bottom: 1em;
+            font-size: 1em;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            box-sizing: border-box;
+        }
+        button {
+            background-color: #4CAF50;
+            color: white;
+            padding: 10px 20px;
+            font-size: 1em;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+        .error-message {
+            color: #d9534f;
+            font-size: 0.9em;
+            margin-top: 1em;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>2FA Authentication Required</h1>
+        <p>Please enter your 2FA code to continue.</p>
+        <form method="POST" action="">
+            <label for="totp_code">2FA Code:</label>
+            <input type="text" id="totp_code" name="totp_code" size="30" maxlength="6" required autofocus>
+            <button type="submit">Submit</button>
+        </form>
+        {{ if .ErrorMessage }}
+        <p class="error-message">{{ .ErrorMessage }}</p>
+        {{ end }}
+    </div>
+</body>
+</html>

--- a/secrets.go
+++ b/secrets.go
@@ -70,5 +70,8 @@ func (m *BasicAuthTOTP) getSecretForUser(username string) (string, error) {
 	if !exists {
 		return "", fmt.Errorf("no TOTP secret found for user %s", username)
 	}
+	if secret == "" {
+		return "", fmt.Errorf("TOTP secret for user %s is empty", username)
+	}
 	return secret, nil
 }


### PR DESCRIPTION
The pull request introduces several enhancements to the `caddy-basicauth-totp` module, focusing on customization and flexibility in two-factor authentication (2FA) implementations.

## 🚀 New Features & Enhancements

### ✨ New `template_file` Directive
- A new `template_file` directive is now available in the Caddyfile configuration.
- This allows administrators to specify a custom HTML template for the 2FA form.
- Enables fully customizable user interfaces to match branding or specific user experience needs.

### 👤 Username Available in Template Context
- The `Username` is now accessible within the template context.
- Custom HTML templates can now dynamically display the current user's name.
- This allows for more personalized and informative 2FA prompts.

### 📜 Embedded Default Template
- The previous hardcoded HTML is now the embedded default HTML template.
- If a custom template is not provided or an error occurs while loading it, the system falls back to this default.
- Ensures uninterrupted flow.

### 🛠️ Refactored Form Handling
- Introduced a dedicated `FormData` struct for handling 2FA form data.
- Improves code readability and maintainability.
- Simplifies the process of managing form inputs.

### 📝 Enhanced Error Logging
- More detailed error messages for failed template loading.
- Facilitates quicker debugging and troubleshooting.

## 📌 Summary
These updates provide greater flexibility for administrators in customizing the 2FA user interface, ensure a reliable fallback mechanism, and improve code structure for maintainability.

---
